### PR TITLE
Avoid hotkeys getting stuck

### DIFF
--- a/ssh-rdp.sh
+++ b/ssh-rdp.sh
@@ -331,14 +331,14 @@ setup_input_loop() {
         if  [ "$DEVNAME" = "$KBDNAME" ] ; then # Device is keyboard -> add it and setup hotkeys
             echo "device add mykbd$i /dev/input/$DEVICE"  >>$NESCRIPT
             if [ $netevent_is == "NEW" ] ; then 
-                echo "hotkey add mykbd$i key:$GRAB_HOTKEY:1 'write-events toggle ; grab-devices toggle'" >>$NESCRIPT
+                echo "hotkey add mykbd$i key:$GRAB_HOTKEY:0 'write-events toggle ; grab-devices toggle'" >>$NESCRIPT
                   else
-                echo "hotkey add mykbd$i key:$GRAB_HOTKEY:1 grab toggle" >>$NESCRIPT
+                echo "hotkey add mykbd$i key:$GRAB_HOTKEY:0 grab toggle" >>$NESCRIPT
             fi
             echo "action set grab-changed exec '/usr/bin/echo Is input forwarded 1=Yes,0=No ? \$NETEVENT_GRABBING' " >>$NESCRIPT
-            echo "hotkey add mykbd$i key:$GRAB_HOTKEY:0 nop" >>$NESCRIPT
-            echo "hotkey add mykbd$i key:$FULLSCREENSWITCH_HOTKEY:1 exec \"/usr/bin/echo FULLSCREENSWITCH_HOTKEY\"" >>$NESCRIPT
-            echo "hotkey add mykbd$i key:$FULLSCREENSWITCH_HOTKEY:0 nop" >>$NESCRIPT
+            echo "hotkey add mykbd$i key:$GRAB_HOTKEY:1 nop" >>$NESCRIPT
+            echo "hotkey add mykbd$i key:$FULLSCREENSWITCH_HOTKEY:0 exec \"/usr/bin/echo FULLSCREENSWITCH_HOTKEY\"" >>$NESCRIPT
+            echo "hotkey add mykbd$i key:$FULLSCREENSWITCH_HOTKEY:1 nop" >>$NESCRIPT
                 else # Device is not keyboard -> just add it
             echo "device add dev$i /dev/input/$DEVICE"  >>$NESCRIPT
         fi


### PR DESCRIPTION
by toggling on key release instead of key press

To observe the issue, use any letter as hotkey, focus a text editor, and press the hotkey. Without this PR, the letter will be printed repeatedly because the system does not see the release event. Ignoring the key press event and toggling on the release event fixes this.